### PR TITLE
Update mobile navigation menu for accessibility and usability

### DIFF
--- a/src/nav/MobileNav.css
+++ b/src/nav/MobileNav.css
@@ -16,6 +16,21 @@
 	height: 3ch;
 }
 
+.menu-label {
+	font-family: var(--sans-serif);
+	font-weight: 700;
+	font-size: 0.8rem;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.05rem;
+}
+
+@media (width < 350px) {
+	.menu-label {
+		display: none;
+	}
+}
+
 #mobile-nav.navigation {
 	display: block;
 }

--- a/src/nav/MobileNav.jsx
+++ b/src/nav/MobileNav.jsx
@@ -28,6 +28,7 @@ const MobileNav = function ({ routes }) {
 						aria-label="Open navigation menu"
 						onClick={handleHamburger}
 					>
+						<span className="menu-label">Menu</span>
 						<img className="nav-icon" src={isMenuOpen ? close : hamburger} alt="Menu icon" />
 					</button>
 				</header>

--- a/src/nav/MobileNav.jsx
+++ b/src/nav/MobileNav.jsx
@@ -34,7 +34,7 @@ const MobileNav = function ({ routes }) {
 				</header>
 				<ul className={`nav-links ${isMenuOpen ? "open" : ""}`}>
 					{routes.map(({ path, label, icon }) => (
-						<li key={path}>
+						<li key={path} onClick={() => setIsMenuOpen(false)}>
 							<NavLink className="nav-link" to={path} aria-label={`Navigate to ${label}`}>
 								<img className="nav-icon" src={icon} alt="" />
 								{label}


### PR DESCRIPTION
- Automatically close the mobile navigation menu when activating a navigation link.
- Add "menu" label to the hamburger icon on screens larger than 350px.