### PR TITLE
Fix: position `.headline__heading` above sibling elements

### DIFF
--- a/src/Headline.css
+++ b/src/Headline.css
@@ -14,6 +14,8 @@
 .headline__heading {
 	position: sticky;
 	top: 7rem;
+	z-index: 1;
+
 	height: fit-content;
 
 	font-weight: 900;
@@ -59,7 +61,7 @@
 		background: linear-gradient(transparent, var(--cl-background) 10%);
 		mix-blend-mode: multiply;
 
-		transform: translateY(-3rem);
+		transform: translateY(-3rem) scaleX(1.1);
 	}
 }
 

--- a/src/nav/DesktopNav.css
+++ b/src/nav/DesktopNav.css
@@ -1,6 +1,6 @@
 .nav__wrapper {
 	position: fixed;
-	z-index: 1;
+	z-index: 2;
 	padding: 1rem 0;
 	width: 100%;
 }


### PR DESCRIPTION
- Apply `z-index: 1` to `.headline__heading`
- Apply `z-index: 2` to `.nav__wrapper` to keep it above `.headline__heading`

Resolves #14